### PR TITLE
Set body's overflow-y to hidden, avoid scrollbar seizure

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -69,6 +69,7 @@ body.dark {
 body {
   @apply p-1.5 flex flex-col items-center justify-center;
   background-color: var(--background);
+  overflow-y: hidden;
 }
 
 .indexLayout {


### PR DESCRIPTION
Antes de este cambio, la barra de scroll aparecia si un copo de nieve bajaba mas alla de la pantalla.

Ahora ya no pasa eso.